### PR TITLE
Move util functions to native JS

### DIFF
--- a/server.js
+++ b/server.js
@@ -172,7 +172,7 @@ async function initFiles() {
     if (!await existsAsync(secretsPath)) {
         console.log('Creating secrets.json with default values...');
         await writeFileAsync(secretsPath, JSON.stringify(defaultSecrets, null, 2));
-        console.log('secrets.json created.');
+        console.log('secrets.json created, please update it with real credentials now and restart the server.');
     }
 }
 


### PR DESCRIPTION
We can now make start scripts simply `npm install --no-audit && npm start` which are OS agnostic. 