### PR TITLE
Refactor config, add API Delete, API URL validation, better testing

### DIFF
--- a/STMP.bat
+++ b/STMP.bat
@@ -6,11 +6,10 @@ ECHO ===========================
 ECHO SillyTavern MultiPlayer
 ECHO ===========================
 
-ECHO -- Checking/Installing Node Modules
+ECHO Checking/Installing Node Modules
 call npm install --no-audit
 title STMP
 ECHO ===========================
-ECHO -- Starting STMP server
 node server.js
 pause
 popd

--- a/public/client.html
+++ b/public/client.html
@@ -169,7 +169,7 @@
 
                                 <div class="flexbox flexFlowCol Hcentered marginTop5">
                                     <div class="flexbox justifySpaceAround">
-                                        <button class="flexbox Vcentered bgBrightUp" id="canceAPIEditButton">Close</button>
+                                        <button class="flexbox Vcentered bgBrightUp" id="cancelAPIEditButton">Close</button>
                                         <button class="flexbox Vcentered bgBrightUp" id="testAPIButton">Test</button>
                                         <button class="flexbox Vcentered bgBrightUp" id="saveAPIButton">Save</button>
                                     </div>

--- a/public/client.html
+++ b/public/client.html
@@ -167,10 +167,15 @@
                                     </div>
                                 </div>
 
-                                <div class="flexbox justifySpaceAround">
-                                    <button class="flexbox Vcentered bgBrightUp" id="canceAPIEditButton">Close</button>
-                                    <button class="flexbox Vcentered bgBrightUp" id="testAPIButton">Test</button>
-                                    <button class="flexbox Vcentered bgBrightUp" id="saveAPIButton">Save</button>
+                                <div class="flexbox flexFlowCol Hcentered marginTop5">
+                                    <div class="flexbox justifySpaceAround">
+                                        <button class="flexbox Vcentered bgBrightUp" id="canceAPIEditButton">Close</button>
+                                        <button class="flexbox Vcentered bgBrightUp" id="testAPIButton">Test</button>
+                                        <button class="flexbox Vcentered bgBrightUp" id="saveAPIButton">Save</button>
+                                    </div>
+                                    <div class="flexbox Hcentered marginTop5">
+                                        <button class="flexbox Hcentered bgBrightUp" id="deleteAPIButton" style="color:red">Delete</button>
+                                    </div>
                                 </div>
                             </div>
 

--- a/public/client.html
+++ b/public/client.html
@@ -34,7 +34,7 @@
                         <h4>AI Config</h4>
                     </div>
                     <div id="AIConfigWrap" class="flexbox flexFlowCol heightFitContent">
-                        <div id="AIConfigInputs" class="flexbox flexFlowCol">
+                        <div id="promptConfig" class="isArrayType flexbox flexFlowCol">
                             <div id="configSelectorsBlock" class="flexbox justifySpaceAround">
                                 <div class="flexbox flexFlowCol">
                                     <small class="alignSelfCenter">Mode</small>
@@ -46,7 +46,7 @@
                                         <small class="alignSelfCenter">API</small>
                                         <div class="flexbox">
                                             <div class="custom-select">
-                                                <select id="apiList"></select>
+                                                <select id="APIList" class="dynamicSelector"></select>
                                             </div>
                                             <!-- <div class="flexbox Vcentered"><button id="addNewAPIButton">Add</button></div> -->
                                             <div class="flexbox Vcentered"><button id="editAPIButton">Edit</button></div>
@@ -54,11 +54,11 @@
                                     </div>
 
                                 </div>
-                                <div id="PromptParameterInputs" class="flexbox justifySpaceAround">
+                                <div id="promptConfigSelectorsAnddToggles" class="flexbox justifySpaceAround">
                                     <div class="flexbox flexFlowCol alignItemsCenter">
                                         <small class="alignSelfCenter">Context</small>
                                         <div class="custom-select">
-                                            <select id="maxContext">
+                                            <select id="contextSize">
                                                 <option value="1024">1024</option>
                                                 <option value="2048">2048</option>
                                                 <option value="4096">4096</option>
@@ -81,32 +81,36 @@
                                             </select>
                                         </div>
                                     </div>
-                                    <div id="streamingChekboxBlock" class="flexbox flexFlowCol widthFitContent">
+                                    <div id="isStreamingChekboxBlock" class="flexbox flexFlowCol widthFitContent">
                                         <small class="alignSelfCenter">Streaming</small>
-                                        <label for="streamingCheckbox" class="checkbox_label flexbox flexFlowCol">
-                                            <input type="checkbox" class="alignSelfCenter margin0" id="streamingCheckbox">
+                                        <label for="isStreaming" class="checkbox_label flexbox flexFlowCol">
+                                            <input type="checkbox" class="alignSelfCenter margin0" id="isStreaming">
+                                        </label>
+                                    </div>
+                                    <div id="isAutoResponseChekboxBlock" class="flexbox flexFlowCol widthFitContent">
+                                        <small class="alignSelfCenter">AutoAI</small>
+                                        <label for="isAutoResponse" class="checkbox_label flexbox flexFlowCol">
+                                            <input type="checkbox" class="Vcentered" id="isAutoResponse">
                                         </label>
                                     </div>
                                     <div class="flexbox flexFlowCol alignItemsCenter">
                                         <small class="alignSelfCenter">Instruct</small>
                                         <div class="custom-select">
-                                            <select id="instructStyle"></select>
+                                            <select id="instructList" class="dynamicSelector"></select>
                                         </div>
                                     </div>
                                     <div class="flexbox flexFlowCol">
                                         <small class="alignSelfCenter">Samplers</small>
                                         <div class="custom-select">
-                                            <select id="samplerPreset"></select>
+                                            <select id="samplerPresetList" class="dynamicSelector"></select>
                                         </div>
                                     </div>
-
-
                                 </div>
                             </div>
-                            <div id="customPromptsBlock" class="transition250 flexbox flexFlowCol">
+                            <div id="promptConfigTextFields" class="transition250 flexbox flexFlowCol">
                                 <div id="systemPromptBlock" class="flexbox flexFlowCol Hcentered dummyBG">
                                     <span class="widthFitContent alignSelfCenter">System Prompt</span>
-                                    <textarea class="bgBrightUp" rows=6 id="systemPromptInput" placeholder="Text in this box will be inserted at the top of the prompt before anything else."></textarea>
+                                    <textarea class="bgBrightUp" rows=6 id="systemPrompt" placeholder="Text in this box will be inserted at the top of the prompt before anything else."></textarea>
                                 </div>
                                 <div id="authorsNoteBlock" class="flexbox flexFlowCol Hcentered dummyBG ">
                                     <div class="flexbox Hcentered">
@@ -117,26 +121,26 @@
                                         </label>
                                     </div>
 
-                                    <textarea class="bgBrightUp" rows=6 id="D4ANInput" placeholder="Useful place to put character definitions, World Info, or other constantly relevant information."></textarea>
+                                    <textarea class="bgBrightUp" rows=6 id="D4AN" placeholder="Useful place to put character definitions, World Info, or other constantly relevant information."></textarea>
                                 </div>
                                 <div id="finalInstructionBlock" class="flexbox flexFlowCol Hcentered dummyBG ">
                                     <span class="widthFitContent alignSelfCenter">D1 Insertion "JB"</span>
-                                    <textarea class="bgBrightUp" rows=6 id="D1JBInput" placeholder="A very powerful override instruction. Mostly useful as a jailbreak for CC APIs. For TC, it is usually too strong and will override the D4 insertion"></textarea>
+                                    <textarea class="bgBrightUp" rows=6 id="D1JB" placeholder="A very powerful override instruction. Mostly useful as a jailbreak for CC APIs. For TC, it is usually too strong and will override the D4 insertion"></textarea>
                                 </div>
                             </div>
                         </div>
-                        <div id="addNewAPI" class="flexbox flexFlowCol width100p" style="display:none;">
+                        <div id="APIConfig" class="isArrayType flexbox flexFlowCol width100p" style="display:none;">
                             <h4 id="apiTitle" class="alignSelfCenter">API Info</h4>
                             <div id="APIEditDiv" class="transition250 flexbox flexFlowCol  padding5 borderRad5">
-                                <small>Name</small><input id="newAPIName" class="width100p" placeholder="API Name">
-                                <small>API Base URL</small><input id="newAPIEndpoint" class="width100p" title="http://127.0.0.1:(port)/ for local backends, or https://what.ever-URL.is/given/ for external/Cloud-based APIs." placeholder="http://127.0.0.1:5000/">
-                                <small>Key</small><input id="newAPIKey" class="width100p" placeholder="API Key (empty if none)">
+                                <small>Name</small><input id="selectedAPI" class="width100p" placeholder="API Name">
+                                <small>API Base URL</small><input id="endpoint" class="width100p" title="http://127.0.0.1:(port)/ for local backends, or https://what.ever-URL.is/given/ for external/Cloud-based APIs." placeholder="http://127.0.0.1:5000/">
+                                <small>Key</small><input id="key" class="width100p" placeholder="API Key (empty if none)">
 
                                 <div class="flexbox Vcentered">
                                     <div class="flexbox flexFlowCol">
                                         <small class="alignSelfCenter">Endpoint Type</small>
                                         <div class="custom-select flexbox flexFlowCol">
-                                            <select id="newAPIEndpointType">
+                                            <select id="type">
                                                 <option value="TC">Text Completion</option>
                                                 <option value="CC">Chat Completion</option>
                                             </select>
@@ -149,14 +153,14 @@
 
                                     <div class="flexbox flexFlowCol ">
                                         <small class="alignSelfCenter">Claude</small>
-                                        <label for="isClaudeCheckbox" class="checkbox_label flexbox flexFlowCol">
-                                            <input type="checkbox" class="alignSelfCenter margin0" id="isClaudeCheckbox">
+                                        <label for="claude" class="checkbox_label flexbox flexFlowCol">
+                                            <input type="checkbox" class="alignSelfCenter margin0" id="claude">
                                         </label>
                                     </div>
                                     <div id="modelListBlock" class="flexbox flexFlowCol">
                                         <small class="alignSelfCenter">Models</small>
                                         <div class="custom-select flexbox flexFlowCol">
-                                            <select id="modelList">
+                                            <select id="modelList" class="dynamicSelector">
                                                 <option>Waiting for Model List</option>
                                             </select>
                                         </div>
@@ -171,7 +175,6 @@
                             </div>
 
                         </div>
-
                     </div>
                 </div>
                 <hr>
@@ -180,25 +183,22 @@
                         <i class="nonButtonButton fa-solid fa-toggle-on bgTransparent fontSize1p25em textshadow"></i>
                         <h4>Crowd Control</h4>
                     </div>
-                    <div id="crowdControlWrap" class="flexbox flexFlowCol heightFitContent">
+                    <div id="crowdControl" class="isArrayType flexbox flexFlowCol heightFitContent">
                         <!-- 
                         <div class="flexbox" style="display:none;">
                             <button id="disableInput" class="flexbox Hcentered Vcentered bgTransparent fontSize1p25em mutedColor textshadow" title="disable User Input">🤐</button>
                             <button id="turnBasedMode" class="flexbox Hcentered Vcentered bgTransparent fontSize1p25em mutedColor textshadow" title="Turn-based Mode">🔠</button>
                         </div>
                          -->
-                        <label for="AIChatInputDelay" class="flexbox noWrap">
+                        <label for="AIChatDelay" class="flexbox noWrap">
                             <div class="fontSize1p25em mutedColor textshadow " title="AI Chat Delay">🤖⏳</div>
-                            <input type="number" id="AIChatInputDelay" class=" flexbox Vcentered width50px" min="0" max="600" value="2" title="AI Chat Delay">sec
+                            <input type="number" id="AIChatDelay" class=" flexbox Vcentered width50px" min="0" max="600" value="2" title="AI Chat Delay">sec
                         </label>
-                        <label for="UserChatInputDelay" class="flexbox noWrap">
+                        <label for="userChatDelay" class="flexbox noWrap">
                             <div class="fontSize1p25em mutedColor textshadow " title="User Chat Delay">🧑⏳</div>
-                            <input type="number" id="UserChatInputDelay" class="flexbox Vcentered width50px" min="0" max="600" value="2" title="User Chat Delay">sec
+                            <input type="number" id="userChatDelay" class="flexbox Vcentered width50px" min="0" max="600" value="2" title="User Chat Delay">sec
                         </label>
-                        <label for="AIAutoResponse" class="checkbox_label flexbox alignItemsCenter">
-                            AutoAI
-                            <input type="checkbox" class="Vcentered" id="AIAutoResponse">
-                        </label>
+
                     </div>
                 </div>
                 <hr>
@@ -256,7 +256,7 @@
                     <div class="chatHeader Hcentered Vcentered flexbox positionRelative marginBot5">
                         Chat with
                         <div class="custom-select hostControls">
-                            <select id="characters" class="flex1"></select>
+                            <select id="cardList" class="flex1 dynamicSelector"></select>
                         </div>
                         <span id="charName"></span>
                     </div>

--- a/public/script.js
+++ b/public/script.js
@@ -679,7 +679,13 @@ window.addEventListener("beforeunload", () => {
 
 
 $(async function () {
-  console.debug("document is ready");
+
+  const $controlPanel = $("#controlPanel");
+  const $LLMChatWrapper = $("#LLMChatWrapper");
+  const $OOCChatWrapper = $("#OOCChatWrapper");
+  const $AIChatInputButtons = $("#AIChatInputButtons");
+  const $UserChatInputButtons = $("#UserChatInputButtons");
+
   let { username, AIChatUsername } = await startupUsernames();
   $("#usernameInput").val(username);
   $("#AIUsernameInput").val(AIChatUsername);
@@ -934,11 +940,7 @@ $(async function () {
       }
     }
   });
-  const $controlPanel = $("#controlPanel");
-  const $LLMChatWrapper = $("#LLMChatWrapper");
-  const $OOCChatWrapper = $("#OOCChatWrapper");
-  const $AIChatInputButtons = $("#AIChatInputButtons");
-  const $UserChatInputButtons = $("#UserChatInputButtons");
+
 
   $("#controlPanelToggle").on("click", async function () {
     await util.betterSlideToggle($controlPanel, 100, "width");
@@ -1031,7 +1033,7 @@ $(async function () {
     control.testNewAPI();
   });
 
-  $("#canceAPIEditButton").on("click", function () {
+  $("#cancelAPIEditButton").on("click", function () {
     util.betterSlideToggle($("#promptConfig"), 250, "height");
     util.betterSlideToggle($("#APIConfig"), 250, "height");
     //select the second option if we cancel out of making a new API

--- a/public/script.js
+++ b/public/script.js
@@ -1114,9 +1114,12 @@ $(async function () {
     util.betterSlideToggle($("#APIConfig"), 250, "height");
   });
 
+  $("#deleteAPIButton").on("click", function () {
+    handleconfig.deleteAPI();
+  });
+
   $("#saveAPIButton").on("click", async function () {
-    await control.addNewAPI();
-    util.betterSlideToggle($("#promptConfig"), 250, "height");
+    await handleconfig.addNewAPI();
   });
   $("#testAPIButton").on("click", function () {
     control.testNewAPI();

--- a/public/script.js
+++ b/public/script.js
@@ -297,7 +297,9 @@ async function connectWebSocket(username) {
     }
 
     /*TODO: 
-        condense anythign that is related to user state into a single message type: 
+    condense all host-facing config updates to and from server into a single message type
+
+        condense anything that is related to user state into a single message type: 
             userList, AIChatUserlist, userconnect, userDisconnect, username change
 
      *condense both clearchats into a single type with a 'chatID' property
@@ -341,8 +343,13 @@ async function connectWebSocket(username) {
       case "forceDisconnect":
         disconnectWebSocket();
         break;
+      case "guestConnectionConfirmed":
+
       case "connectionConfirmed":
         processConfirmedConnection(parsedMessage);
+        break;
+      case "hostStateChange":
+        handleconfig.processLiveConfig(parsedMessage);
         break;
       case "userChangedName":
         console.debug("saw notification of user name change");
@@ -421,10 +428,6 @@ async function connectWebSocket(username) {
       case "pastChatsList":
         let chatList = parsedMessage.pastChats;
         control.showPastChats(chatList);
-        break;
-      case "APIList":
-        let APIList = parsedMessage.APIList;
-        control.populateAPISelector(APIList, parsedMessage.selectedAPI);
         break;
       case "pastChatToLoad":
         console.debug("loading past chat session");
@@ -751,6 +754,7 @@ window.addEventListener("beforeunload", () => {
   }
 });
 
+
 $(async function () {
   console.debug("document is ready");
   let { username, AIChatUsername } = await startupUsernames();
@@ -791,150 +795,65 @@ $(async function () {
     }
   });
 
-  $("#AIAutoResponse").on("input", function () {
-    isAutoResponse = $(this).prop("checked");
-    console.debug(`AutoResponse = ${isAutoResponse}`);
-    const autoResponseStateMessage = {
-      type: "toggleAutoResponse",
-      UUID: myUUID,
-      value: isAutoResponse,
-    };
-    util.messageServer(autoResponseStateMessage);
-    util.flashElement("AIAutoResponse", "good");
-  });
 
-  $("#streamingCheckbox").on("input", function () {
-    isStreaming = $(this).prop("checked");
-    console.debug(`Streaming = ${isStreaming}`);
-    const streamingStateMessage = {
-      type: "toggleStreaming",
-      UUID: myUUID,
-      value: isStreaming,
-    };
-    util.messageServer(streamingStateMessage);
-    util.flashElement("streamingCheckbox", "good");
-  });
-
-  $("#D4CharDefs").on("input", function () {
-    let D4CharDefs = $(this).prop("checked");
-    console.debug(`D4 Char Defs = ${D4CharDefs}`);
-    const D4CharDefsMessage = {
-      type: "toggleD4CharDefs",
-      UUID: myUUID,
-      value: D4CharDefs,
-    };
-    util.messageServer(D4CharDefsMessage);
-    util.flashElement("D4CharDefs", "good");
-  });
-
-  $("#maxContext").on("input", function () {
-    contextSize = $(this).find(`option:selected`).val();
-    const adjustCtxMes = {
-      type: "adjustContextSize",
-      UUID: myUUID,
-      value: contextSize,
-    };
-    util.messageServer(adjustCtxMes);
-    util.flashElement("maxContext", "good");
-  });
-
-  $("#responseLength").on("input", function () {
-    responseLength = $(this).find(`option:selected`).val();
-    const adjustResponseLength = {
-      type: "adjustResponseLength",
-      UUID: myUUID,
-      value: responseLength,
-    };
-    util.messageServer(adjustResponseLength);
-    util.flashElement("responseLength", "good");
-  });
 
   // Send a message to the user chat
-  $("#sendButton")
-    .off("click")
-    .on("click", function () {
-      if ($(this).hasClass("disabledButton")) {
-        return;
-      }
-      if ($("#usernameInput").val().trim() === "") {
-        alert("Can't send chat message with no username!");
-        return;
-      }
-      var messageInput = $("#messageInput");
-      if (messageInput.val().trim() === "") {
-        alert("Can't send empty message!");
-        return;
-      }
+  $("#sendButton").off("click").on("click", function () {
 
-      $(this).addClass("disabledButton").text("🚫");
-      setTimeout(() => {
-        $(this).removeClass("disabledButton").text("✏️");
-      }, userChatDelay);
+    if ($(this).hasClass("disabledButton")) {
+      return;
+    }
+    if ($("#usernameInput").val().trim() === "") {
+      alert("Can't send chat message with no username!");
+      return;
+    }
+    var messageInput = $("#messageInput");
+    if (messageInput.val().trim() === "") {
+      alert("Can't send empty message!");
+      return;
+    }
 
-      username = $("#usernameInput").val();
-      var markdownContent = `${messageInput.val()}`;
-      //var htmlContent = converter.makeHtml(markdownContent);
-      var messageObj = {
-        type: "chatMessage",
-        chatID: "UserChat",
-        UUID: myUUID,
-        username: username,
-        content: markdownContent,
-      };
-      localStorage.setItem("username", username);
-      util.messageServer(messageObj);
-      messageInput.val("");
-      messageInput.trigger("focus").trigger("input");
-    });
+    $(this).addClass("disabledButton").text("🚫");
+    setTimeout(() => {
+      $(this).removeClass("disabledButton").text("✏️");
+    }, userChatDelay);
 
-  $("#triggerAIResponse")
-    .off("click")
-    .on("click", function () {
-      sendMessageToAIChat("forced");
-    });
-
-  $("#AIRetry")
-    .off("click")
-    .on("click", function () {
-      doAIRetry();
-    });
-
-  $("#characters").on("change", function () {
-    let displayName = $("#characters").find("option:selected").text();
-    control.updateSelectedChar(myUUID, $(this).val(), displayName);
+    username = $("#usernameInput").val();
+    var markdownContent = `${messageInput.val()}`;
+    //var htmlContent = converter.makeHtml(markdownContent);
+    var messageObj = {
+      type: "chatMessage",
+      chatID: "UserChat",
+      UUID: myUUID,
+      username: username,
+      content: markdownContent,
+    };
+    localStorage.setItem("username", username);
+    util.messageServer(messageObj);
+    messageInput.val("");
+    messageInput.trigger("focus").trigger("input");
   });
 
-  $("#samplerPreset").on("change", function () {
-    control.updateSelectedSamplerPreset(myUUID, $(this).val());
-  });
-  $("#instructStyle").on("change", function () {
-    control.updateInstructFormat(myUUID, $(this).val());
-  });
-  $("#D1JBInput").on("blur", function () {
-    control.updateD1JBInput(myUUID, $(this).val());
-  });
-  $("#D4ANInput").on("blur", function () {
-    control.updateD4ANInput(myUUID, $(this).val());
-  });
-  $("#systemPromptInput").on("blur", function () {
-    control.updateSystemPromptInput(myUUID, $(this).val());
+  $("#triggerAIResponse").off("click").on("click", function () {
+    sendMessageToAIChat("forced");
   });
 
+  $("#AIRetry").off("click").on("click", function () {
+    doAIRetry();
+  });
 
   //A clickable icon that toggles between Text Completions and horde mode, swaps the API parameters, and updates the UI and server to reflect the change.
-  $("#toggleMode")
-    .off("click")
-    .on("click", async function () {
-      let newMode = $("#toggleMode").hasClass("hordeMode") ? "TC" : "horde";
-      await handleconfig.setEngineMode(newMode)
+  $("#toggleMode").off("click").on("click", async function () {
+    let newMode = $("#toggleMode").hasClass("hordeMode") ? "TC" : "horde";
+    await handleconfig.setEngineMode(newMode)
 
-      let modeChangeMessage = {
-        type: "modeChange",
-        UUID: myUUID,
-        newMode: newMode,
-      };
-      util.messageServer(modeChangeMessage);
-    });
+    let modeChangeMessage = {
+      type: "modeChange",
+      UUID: myUUID,
+      newMode: newMode,
+    };
+    util.messageServer(modeChangeMessage);
+  });
 
   $("#usernameInput").on("blur", function () {
     console.debug("saw username input blur");
@@ -951,52 +870,46 @@ $(async function () {
     control.updateAIChatUserName();
   });
 
-  $("#AISendButton")
-    .off("click")
-    .on("click", function () {
-      if ($(this).hasClass("disabledButton")) {
-        return;
-      }
-      sendMessageToAIChat();
-      $("#AIMessageInput").trigger("input");
-      $(this).addClass("disabledButton").text("🚫");
-      setTimeout(() => {
-        $(this).removeClass("disabledButton").text("✏️");
-      }, AIChatDelay);
-    });
+  $("#AISendButton").off("click").on("click", function () {
+    if ($(this).hasClass("disabledButton")) {
+      return;
+    }
+    sendMessageToAIChat();
+    $("#AIMessageInput").trigger("input");
+    $(this).addClass("disabledButton").text("🚫");
+    setTimeout(() => {
+      $(this).removeClass("disabledButton").text("✏️");
+    }, AIChatDelay);
+  });
 
-  $("#clearUserChat")
-    .off("click")
-    .on("click", function () {
-      console.debug("Requesting OOC Chat clear");
-      const clearMessage = {
-        type: "clearChat",
-        UUID: myUUID,
-      };
-      util.messageServer(clearMessage);
-    });
 
-  $("#clearAIChat")
-    .off("click")
-    .on("click", function () {
-      console.debug("Requesting AI Chat clear");
-      const clearMessage = {
-        type: "clearAIChat",
-        UUID: myUUID,
-      };
-      util.messageServer(clearMessage);
-    });
+  $("#clearUserChat").off("click").on("click", function () {
 
-  $("#deleteLastMessageButton")
-    .off("click")
-    .on("click", function () {
-      console.debug("deleting last AI Chat message");
-      const delLastMessage = {
-        type: "deleteLast",
-        UUID: myUUID,
-      };
-      util.messageServer(delLastMessage);
-    });
+    console.debug("Requesting OOC Chat clear");
+    const clearMessage = {
+      type: "clearChat",
+      UUID: myUUID,
+    };
+    util.messageServer(clearMessage);
+  });
+
+  $("#clearAIChat").off("click").on("click", function () {
+    console.debug("Requesting AI Chat clear");
+    const clearMessage = {
+      type: "clearAIChat",
+      UUID: myUUID,
+    };
+    util.messageServer(clearMessage);
+  });
+
+  $("#deleteLastMessageButton").off("click").on("click", function () {
+    console.debug("deleting last AI Chat message");
+    const delLastMessage = {
+      type: "deleteLast",
+      UUID: myUUID,
+    };
+    util.messageServer(delLastMessage);
+  });
 
   $("#profileManagementButton").on("click", function () {
     util.betterSlideToggle($("#profileManagementMenu"), 250, "width");
@@ -1109,42 +1022,38 @@ $(async function () {
   });
 
   var chatsToggleState = 0;
-  $("#chatsToggle")
-    .off("click")
-    .on("click", async function () {
-      chatsToggleState = (chatsToggleState + 1) % 3; // Increment the state and wrap around to 0 after the third state
-      if (chatsToggleState === 0) {
-        $LLMChatWrapper
-          .removeClass("transition500")
-          .css({ flex: "1", opacity: "1" });
-        $OOCChatWrapper
-          .removeClass("transition500")
-          .css({ flex: "1", opacity: "1" });
-        if (!isPhone && isLandscape) {
-          $("body").removeClass("halfWidthChatWrap");
-        }
-      } else if (chatsToggleState === 1) {
-        $OOCChatWrapper.css({ flex: "0", opacity: "0" });
-        console.log(isPhone, isLandscape);
-        if (!isPhone && isLandscape) {
-          $("body").addClass("halfWidthChatWrap");
-        }
-      } else if (chatsToggleState === 2) {
-        $OOCChatWrapper
-          .addClass("transition500")
-          .css({ flex: "1", opacity: "1" });
-        $LLMChatWrapper
-          .addClass("transition500")
-          .css({ flex: "0", opacity: "0" });
+  $("#chatsToggle").off("click").on("click", async function () {
+    chatsToggleState = (chatsToggleState + 1) % 3; // Increment the state and wrap around to 0 after the third state
+    if (chatsToggleState === 0) {
+      $LLMChatWrapper
+        .removeClass("transition500")
+        .css({ flex: "1", opacity: "1" });
+      $OOCChatWrapper
+        .removeClass("transition500")
+        .css({ flex: "1", opacity: "1" });
+      if (!isPhone && isLandscape) {
+        $("body").removeClass("halfWidthChatWrap");
       }
-    });
+    } else if (chatsToggleState === 1) {
+      $OOCChatWrapper.css({ flex: "0", opacity: "0" });
+      console.log(isPhone, isLandscape);
+      if (!isPhone && isLandscape) {
+        $("body").addClass("halfWidthChatWrap");
+      }
+    } else if (chatsToggleState === 2) {
+      $OOCChatWrapper
+        .addClass("transition500")
+        .css({ flex: "1", opacity: "1" });
+      $LLMChatWrapper
+        .addClass("transition500")
+        .css({ flex: "0", opacity: "0" });
+    }
+  });
 
-  $("#userListsToggle")
-    .off("click")
-    .on("click", function () {
-      util.betterSlideToggle($("#AIChatUserList"), 250, "width");
-      util.betterSlideToggle($("#userList"), 250, "width");
-    });
+  $("#userListsToggle").off("click").on("click", function () {
+    util.betterSlideToggle($("#AIChatUserList"), 250, "width");
+    util.betterSlideToggle($("#userList"), 250, "width");
+  });
 
   //this auto resizes the chat input box as the input gets longer
   $("#AIMessageInput, #messageInput").on("input", function () {
@@ -1195,60 +1104,30 @@ $(async function () {
     util.flashElement(this.id, "good");
   });
 
-  $("#apiList").on("change", function () {
-    if ($(this).val() === "Default") {
-      return;
-    }
 
-    console.debug("[#apilist] changed");
-    if ($(this).val() === "addNewAPI") {
-      console.debug('[#apilist]...to "addNewApi"');
-      //clear all inputs for API editing
-      $("#addNewAPI input").val("");
-      control.enableAPIEdit();
-      //hide API config, show API edit panel.
-      util.betterSlideToggle($("#AIConfigInputs"), 250, "height");
-      util.betterSlideToggle($("#addNewAPI"), 250, "height");
-      return;
-    } else {
-      console.debug(`[#apilist]...to "${$(this).val()}"`);
-      if ($("#addNewAPI").css("display") !== "none") {
-        util.betterSlideToggle($("#addNewAPI"), 250, "height");
-        control.hideAddNewAPIDiv();
-      }
-      if ($("#AIConfigInputs").css("display") === "none") {
-        util.betterSlideToggle($("#AIConfigInputs"), 250, "height");
-      }
-    }
-    const APIChangeMessage = {
-      type: "APIChange",
-      UUID: myUUID,
-      newAPI: $(this).val(),
-    };
-    util.messageServer(APIChangeMessage);
-    util.flashElement("apiList", "good");
-  });
+
+
 
   $("#editAPIButton").on("click", function () {
     control.enableAPIEdit();
-    util.betterSlideToggle($("#AIConfigInputs"), 250, "height");
-    util.betterSlideToggle($("#addNewAPI"), 250, "height");
+    util.betterSlideToggle($("#promptConfig"), 250, "height");
+    util.betterSlideToggle($("#APIConfig"), 250, "height");
   });
 
   $("#saveAPIButton").on("click", async function () {
     await control.addNewAPI();
-    util.betterSlideToggle($("#AIConfigInputs"), 250, "height");
+    util.betterSlideToggle($("#promptConfig"), 250, "height");
   });
   $("#testAPIButton").on("click", function () {
     control.testNewAPI();
   });
 
   $("#canceAPIEditButton").on("click", function () {
-    util.betterSlideToggle($("#AIConfigInputs"), 250, "height");
-    util.betterSlideToggle($("#addNewAPI"), 250, "height");
+    util.betterSlideToggle($("#promptConfig"), 250, "height");
+    util.betterSlideToggle($("#APIConfig"), 250, "height");
     //select the second option if we cancel out of making a new API
     //this is not ideal and shuld really select whatever was selected previous before 'add new api' was selected.
-    if ($("#apiList").val() === "addNewAPI") {
+    if ($("#apiList").val() === "APIConfig") {
       $("#apiList option:eq(1)").prop("selected", "width");
     }
   });

--- a/public/script.js
+++ b/public/script.js
@@ -478,28 +478,22 @@ async function connectWebSocket(username) {
           .prop("selected", true);
         console.debug("maxContext updated");
         break;
-      case "apiChange":
-        $("#apiList")
-          .find(`option[value="${parsedMessage.name}"]`)
-          .prop("selected", true);
-        $("#modelList").empty().attr("disabled", false);
-        // Update the Name, endpoint, and key fields with the new API info
-        control.populateAPIValues(parsedMessage);
-        util.flashElement("newAPIName", "good");
-        util.flashElement("newAPIEndpoint", "good");
-        util.flashElement("newAPIKey", "good");
-        util.flashElement("newAPIEndpointType", "good");
-        util.flashElement("isClaudeCheckbox", "good");
-        util.flashElement("apiList", "good");
-        break;
       case "testAPIResult":
-        let result = parsedMessage.value;
+        let result = parsedMessage.result;
         console.debug(result);
         if (result.status === 200) {
           util.flashElement("APIEditDiv", "good");
         } else {
+          let alertMessage
+          if (!result.status || !result.statusText) {
+            let reason = JSON.stringify(result)
+            alertMessage = `Error ${reason}`
+          } else {
+            alertMessage = `Error [${result.status}]: ${result.statusText}`
+          }
+
           await util.flashElement("APIEditDiv", "bad", 150, 3);
-          alert(`Error: status code ${result.status}`);
+          alert(alertMessage);
         }
         break;
       case "modelListResult":
@@ -1090,23 +1084,6 @@ $(async function () {
 
   AIChatDelay = $("#AIChatInputDelay").val() * 1000;
   userChatDelay = $("#UserChatInputDelay").val() * 1000;
-
-  $("#UserChatInputDelay, #AIChatInputDelay").on("change", function () {
-    const messageType =
-      this.id === "UserChatInputDelay"
-        ? "userChatDelayChange"
-        : "AIChatDelayChange";
-    const settingsChangeMessage = {
-      type: messageType,
-      value: $(this).val(),
-    };
-    util.messageServer(settingsChangeMessage);
-    util.flashElement(this.id, "good");
-  });
-
-
-
-
 
   $("#editAPIButton").on("click", function () {
     control.enableAPIEdit();

--- a/public/script.js
+++ b/public/script.js
@@ -379,41 +379,6 @@ async function connectWebSocket(username) {
         let newCharDisplayName = parsedMessage.charDisplayName;
         $("#charName").text(newCharDisplayName);
         break;
-      case "changeSamplerPreset":
-        let currentPreset = $("#samplerPreset").val();
-        let newPreset = parsedMessage.newPreset;
-        if (currentPreset !== newPreset) {
-          control.updateSelectedSamplerPreset(myUUID, newPreset, "forced");
-        }
-        break;
-      case "changeInstructFormat":
-        let currentFormat = $("#instructStyle").val();
-        let newFormat = parsedMessage.newInstructFormat;
-        if (currentFormat !== newFormat) {
-          control.updateInstructFormat(myUUID, newFormat, "forced");
-        }
-        break;
-      case "changeD1JB":
-        let currentJB = $("#D1JBInput").val();
-        let newJB = parsedMessage.newD1JB;
-        if (currentJB !== newJB) {
-          control.updateD1JBInput(myUUID, newJB, "forced");
-        }
-        break;
-      case "changeD4AN":
-        let currentD4AN = $("#D4ANInput").val();
-        let newD4AN = parsedMessage.newD4AN;
-        if (currentD4AN !== newD4AN) {
-          control.updateD4ANInput(myUUID, newD4AN, "forced");
-        }
-        break;
-      case "changeSystemPrompt":
-        let currentSystemPrompt = $("#systemPromptInput").val();
-        let newSystemPrompt = parsedMessage.newSystemPrompt;
-        if (currentSystemPrompt !== newSystemPrompt) {
-          control.updateSystemPromptInput(myUUID, newSystemPrompt, "forced");
-        }
-        break;
       case "keyAccepted":
         //refresh page to get new info, could be done differently in the future
         await util.flashElement("roleKeyInput", "good");
@@ -456,28 +421,6 @@ async function connectWebSocket(username) {
         }
         $("#showPastChats").trigger("click");
         break;
-      case "autoAItoggleUpdate":
-        $("#AIAutoResponse").prop("checked", parsedMessage.value);
-        console.debug("autoAI toggle updated");
-        break;
-      case "streamingToggleUpdate":
-        $("#streamingCheckbox").prop("checked", parsedMessage.value);
-        console.debug("streaming toggle updated");
-        break;
-      case "D4CharDefsToggleUpdate":
-        $("#D4CharDefs").prop("checked", parsedMessage.value);
-        console.debug("D4 Char Defs toggle updated");
-        break;
-      case "claudeToggleUpdate":
-        $("#isClaudeCheckbox").prop("checked", parsedMessage.value);
-        console.debug("Claude toggle updated");
-        break;
-      case "contextSizeChange":
-        $("#maxContext")
-          .find(`option[value="${parsedMessage.value}"]`)
-          .prop("selected", true);
-        console.debug("maxContext updated");
-        break;
       case "testAPIResult":
         let result = parsedMessage.result;
         console.debug(result);
@@ -508,20 +451,6 @@ async function connectWebSocket(username) {
       case "modelChange":
         let selectedModel = parsedMessage.value;
         control.updateSelectedModel(selectedModel);
-        break;
-      case "responseLengthChange":
-        $("#responseLength")
-          .find(`option[value="${parsedMessage.value}"]`)
-          .prop("selected", true);
-        console.debug("responseLength updated");
-        break;
-      case "AIChatDelayChange":
-        AIChatDelay = parsedMessage.value * 1000;
-        console.debug("AI Chat delay updated");
-        break;
-      case "userChatDelayChange":
-        userChatDelay = parsedMessage.value * 1000;
-        console.debug("User Chat delay updated");
         break;
       case "streamedAIResponse":
         $("body").addClass("currentlyStreaming");

--- a/public/src/controls.js
+++ b/public/src/controls.js
@@ -192,10 +192,10 @@ async function populateModelsList(list) {
     $("#modelList option:eq(1)").prop('selected', true).trigger('input')
 }
 
-async function populateAPISelector(API, selectedAPI) {
+/* async function populateAPISelector(API, selectedAPI) {
 
     console.debug('[populateAPISelector()] >> GO')
-    let APISelectElement = $("#apiList");
+    let APISelectElement = $("#APIList");
     APISelectElement.empty()
     APISelectElement.append($('<option>').val('addNewAPI').text('Add New API'));
     for (const api of API) {
@@ -208,21 +208,21 @@ async function populateAPISelector(API, selectedAPI) {
         console.debug(`selectedAPI = ${selectedAPI}..selecting it.`)
         $("#apiList").find(`option[value="${selectedAPI}"]`).prop('selected', true)
     }
-}
+} */
 
 function showAddNewAPIDiv() {
     //console.debug('showing div for adding new API')
-    $("#addNewAPI").show()
+    $("#APIConfig").show()
     $("#addNewAPIButton").show()
     $("#editAPIButton").hide()
-    $("#newAPIName").val('')
-    $("#newAPIEndpoint").val('')
-    $("#newAPIKey").val('')
-    $("#newAPIEndpointType").val('TC')
-    $("#newAPIEndpointType").prop('disabled', false)
-    $("#newAPIName").prop('readonly', false)
-    $("#newAPIEndpoint").prop('readonly', false)
-    $("#newAPIKey").prop('readonly', false)
+    $("#selectedAPI").val('')
+    $("#endpoint").val('')
+    $("#key").val('')
+    $("#type").val('TC')
+    $("#type").prop('disabled', false)
+    $("#selectedAPI").prop('readonly', false)
+    $("#endpoint").prop('readonly', false)
+    $("#key").prop('readonly', false)
     $("#apiTitle").text('New API Info')
     $("#saveAPIButton").show()
 }
@@ -231,20 +231,16 @@ function hideAddNewAPIDiv() {
     console.debug('[hideAddNewAPIDiv()] >> GO')
     $("#addNewAPIButton").hide()
     $("#editAPIButton").show()
-    //$("#newAPIName").prop('readonly', true)
-    //$("#newAPIEndpoint").prop('readonly', true)
-    //$("#newAPIKey").prop('readonly', true)
-    //$("#newAPIEndpointType").prop('disabled', true)
-    $("#addNewAPI").hide()
+    $("#APIConfig").hide()
     $("#saveAPIButton").hide()
 }
 
 function enableAPIEdit() {
     console.debug('[enableAPIEdit()] >> GO')
-    $("#newAPIName").prop('readonly', false)
-    $("#newAPIEndpoint").prop('readonly', false)
-    $("#newAPIKey").prop('readonly', false)
-    $("#newAPIEndpointType").prop('disabled', false)
+    $("#selectedAPI").prop('readonly', false)
+    $("#endpoint").prop('readonly', false)
+    $("#key").prop('readonly', false)
+    $("#type").prop('disabled', false)
     $("#saveAPIButton").show()
     //Set the title 
     $("#apiTitle").text('Edit API Info')
@@ -252,10 +248,10 @@ function enableAPIEdit() {
 
 function disableAPIEdit() {
     console.debug('[disableAPIEdit()] >> GO')
-    $("#newAPIName").prop('readonly', true)
-    $("#newAPIEndpoint").prop('readonly', true)
-    $("#newAPIKey").prop('readonly', true)
-    $("#newAPIEndpointType").prop('disabled', true)
+    $("#selectedAPI").prop('readonly', true)
+    $("#endpoint").prop('readonly', true)
+    $("#key").prop('readonly', true)
+    $("#type").prop('disabled', true)
     $("#saveAPIButton").hide()
     //Set the title 
     $("#apiTitle").text('')
@@ -263,11 +259,11 @@ function disableAPIEdit() {
 
 async function populateAPIValues(api) {
     console.debug(api)
-    $("#newAPIName").val(api.name)
-    $("#newAPIKey").val(api.key)
-    $("#newAPIEndpoint").val(api.endpoint)
-    $("#newAPIEndpointType").find(`option[value="${api.endpointType}"]`).prop('selected', true)
-    $("#isClaudeCheckbox").prop('checked', api.claude)
+    $("#selectedAPI").val(api.name)
+    $("#endpoint").val(api.key)
+    $("#key").val(api.endpoint)
+    $("#type").find(`option[value="${api.endpointType}"]`).prop('selected', true)
+    $("#claude").prop('checked', api.claude)
     // hide the add button, only do it through the selector
     // can change this later if we need to, if a button is more intuitive.
     $("#addNewAPIButton").hide()
@@ -281,19 +277,18 @@ async function populateAPIValues(api) {
 async function addNewAPI() {
     //check each field for validity, flashElement if invalid
     console.debug('[addNewAPI()] >> GO')
-    let name = $("#newAPIName").val()
-    let endpoint = $("#newAPIEndpoint").val()
-    let key = $("#newAPIKey").val()
-    let type = $("#newAPIEndpointType").val()
-    let claude = $("#isClaudeCheckbox").prop('checked')
-    console.log(`Claude value: ${claude}`)
+    let name = $("#selectedAPI").val()
+    let endpoint = $("#endpoint").val()
+    let key = $("#key").val()
+    let type = $("#type").val()
+    let claude = $("#claude").prop('checked')
 
     if (name === '') {
-        await util.flashElement('newAPIName', 'bad')
+        await util.flashElement('selectedAPI', 'bad')
         return
     }
     if (endpoint === '') {
-        await util.flashElement('newAPIEndpoint', 'bad')
+        await util.flashElement('endpoint', 'bad')
         return
     }
 
@@ -308,7 +303,7 @@ async function addNewAPI() {
     })
     await util.delay(250)
     //hide edit panel after save is done
-    util.betterSlideToggle($("#addNewAPI"), 250, 'height')
+    util.betterSlideToggle($("#APIConfig"), 250, 'height')
     disableAPIEdit()
 
 }
@@ -415,8 +410,8 @@ function showPastChats(chatList) {
 }
 
 export default {
-    populateAPISelector,
-    populateSelector,
+    //populateAPISelector,
+    //populateSelector,
     submitKey,
     updateUserName,
     updateD1JBInput,
@@ -425,7 +420,7 @@ export default {
     updateSelectedChar,
     updateAIChatUserName,
     updateAPI,
-    populateAPIValues,
+    //populateAPIValues,
     showAddNewAPIDiv,
     hideAddNewAPIDiv,
     addNewAPI,

--- a/public/src/controls.js
+++ b/public/src/controls.js
@@ -272,42 +272,6 @@ async function populateAPIValues(api) {
     $("#modelLoadButton").trigger('click')
 }
 
-
-
-async function addNewAPI() {
-    //check each field for validity, flashElement if invalid
-    console.debug('[addNewAPI()] >> GO')
-    let name = $("#selectedAPI").val()
-    let endpoint = $("#endpoint").val()
-    let key = $("#key").val()
-    let type = $("#type").val()
-    let claude = $("#claude").prop('checked')
-
-    if (name === '') {
-        await util.flashElement('selectedAPI', 'bad')
-        return
-    }
-    if (endpoint === '') {
-        await util.flashElement('endpoint', 'bad')
-        return
-    }
-
-    util.messageServer({
-        type: 'addNewAPI',
-        name: name,
-        endpoint: endpoint,
-        key: key,
-        endpointType: type,
-        claude: claude,
-        UUID: myUUID
-    })
-    await util.delay(250)
-    //hide edit panel after save is done
-    util.betterSlideToggle($("#APIConfig"), 250, 'height')
-    disableAPIEdit()
-
-}
-
 function testNewAPI() {
     let name = $("#newAPIName").val()
     let endpoint = $("#newAPIEndpoint").val()
@@ -423,7 +387,7 @@ export default {
     //populateAPIValues,
     showAddNewAPIDiv,
     hideAddNewAPIDiv,
-    addNewAPI,
+    //addNewAPI,
     testNewAPI,
     getModelList,
     enableAPIEdit,

--- a/public/src/controls.js
+++ b/public/src/controls.js
@@ -1,117 +1,11 @@
 import util from './utils.js'
 import { isUserScrollingAIChat, isUserScrollingUserChat, myUUID } from '../script.js'
 
-function updateSelectedChar(myUUID, char, displayName, type) {
-    console.debug(char, displayName)
-    $("#charName").text(displayName)
-    if (type === 'forced') { //if server ordered it
-        console.debug('changing Char from server command')
-        $("#characters").find(`option[value="${char}"]`).prop('selected', true)
-    } else { //if user did it
-        //let newChar = String($("#characters").val())
-        console.debug('I manually changed char, and updating to server')
-        let newCharDisplayName = $("#characters").find(`option[value="${char}"]`).text()
-        let changeCharacterRequest = {
-            type: 'changeCharacterRequest',
-            UUID: myUUID,
-            newChar: char,
-            newCharDisplayName: newCharDisplayName
-        }
-        util.messageServer(changeCharacterRequest);
-    }
-    util.flashElement('characters', 'good')
-}
-
-function updateSelectedSamplerPreset(myUUID, preset, type) {
-    console.debug(preset)
-    if (type === 'forced') {
-        console.debug('changing preset from server command')
-        $("#samplerPreset").find(`option[value="${preset}"]`).prop('selected', true)
-    } else {
-        console.debug('I manually changed char, and updating to server')
-        let changeSamplerPresetMessage = {
-            type: 'changeSamplerPreset',
-            UUID: myUUID,
-            newPreset: preset
-        }
-        util.messageServer(changeSamplerPresetMessage);
-    }
-    util.flashElement('samplerPreset', 'good')
-}
 
 function updateSelectedModel(model) {
     console.debug(`[updateSelectedModel()] Changing model from server command to ${model}.`)
     $("#modelList").find(`option[value="${model}"]`).prop('selected', true).trigger('change')
     util.flashElement('modelList', 'good')
-}
-
-function updateInstructFormat(myUUID, format, type) {
-    console.debug(format)
-    if (type === 'forced') {
-        console.debug('changing Instruct format from server command')
-        $("#instructStyle").find(`option[value="${format}"]`).prop('selected', true)
-
-    } else {
-        console.debug('I manually changed Instruct format, and updating to server')
-        let changeInstructFormatMessage = {
-            type: 'changeInstructFormat',
-            UUID: myUUID,
-            newInstructFormat: format
-        }
-        util.messageServer(changeInstructFormatMessage);
-    }
-    util.flashElement('instructStyle', 'good')
-}
-
-function updateD1JBInput(myUUID, jb, type) {
-    console.debug(jb, type)
-    if (type === 'forced') {
-        console.debug('changing D1JB from server command')
-        $("#D1JBInput").val(jb)
-    } else {
-        console.debug('I manually changed D1JB, and updating to server')
-        let changeD1JBMessage = {
-            type: 'changeD1JB',
-            UUID: myUUID,
-            newD1JB: jb
-        }
-        util.messageServer(changeD1JBMessage);
-    }
-    util.flashElement('D1JBInput', 'good')
-}
-
-function updateD4ANInput(myUUID, D4AN, type) {
-    console.debug(D4AN, type)
-    if (type === 'forced') {
-        console.debug('changing D1JB from server command')
-        $("#D4ANInput").val(D4AN)
-    } else {
-        console.debug('I manually changed D4AN, and updating to server')
-        let changeD4ANMessage = {
-            type: 'changeD4AN',
-            UUID: myUUID,
-            newD4AN: D4AN
-        }
-        util.messageServer(changeD4ANMessage);
-    }
-    util.flashElement('D4ANInput', 'good')
-}
-
-function updateSystemPromptInput(myUUID, systemPrompt, type) {
-    console.debug(systemPrompt, type)
-    if (type === 'forced') {
-        console.debug('changing D1JB from server command')
-        $("#systemPromptInput").val(systemPrompt)
-    } else {
-        console.debug('I manually changed system Prompt, and updating to server')
-        let changeSystemPromptMessage = {
-            type: 'changeSystemPrompt',
-            UUID: myUUID,
-            newSystemPrompt: systemPrompt
-        }
-        util.messageServer(changeSystemPromptMessage);
-    }
-    util.flashElement('systemPromptInput', 'good')
 }
 
 function updateUserName(myUUID, username) {
@@ -127,17 +21,6 @@ function updateUserName(myUUID, username) {
     util.messageServer(nameChangeMessage)
     util.flashElement('usernameInput', 'good')
 }
-
-function updateAPI(myUUID, api) {
-    let apiChangeMessage = {
-        type: 'apiChange',
-        UUID: myUUID,
-        newAPI: api
-    }
-    util.messageServer(apiChangeMessage)
-    util.flashElement('apiList', 'good')
-}
-
 
 //Just update Localstorage, no need to send anything to server for this.
 //but possibly add it in the future if we want to let users track which user is speaking as which entity in AI Chat.
@@ -161,19 +44,6 @@ function submitKey(myUUID) {
     util.messageServer(keyMessage)
 }
 
-async function populateSelector(list, elementId) {
-    console.debug(list);
-    const selectElement = $(`#${elementId}`);
-    selectElement.empty();
-
-    for (const item of list) {
-        const newElem = $('<option>');
-        newElem.val(item.filename);
-        newElem.text(item.name);
-        selectElement.append(newElem);
-    }
-}
-
 async function populateModelsList(list) {
     console.debug('[populateModelList()] >> GO')
     const $selector = $('#modelList');
@@ -191,24 +61,6 @@ async function populateModelsList(list) {
     console.debug('selecting the second entry of #apilist..should be "Default"')
     $("#modelList option:eq(1)").prop('selected', true).trigger('input')
 }
-
-/* async function populateAPISelector(API, selectedAPI) {
-
-    console.debug('[populateAPISelector()] >> GO')
-    let APISelectElement = $("#APIList");
-    APISelectElement.empty()
-    APISelectElement.append($('<option>').val('addNewAPI').text('Add New API'));
-    for (const api of API) {
-        let newElem = $('<option>');
-        newElem.val(api.name);
-        newElem.text(api.name);
-        APISelectElement.append(newElem);
-    }
-    if (selectedAPI) {
-        console.debug(`selectedAPI = ${selectedAPI}..selecting it.`)
-        $("#apiList").find(`option[value="${selectedAPI}"]`).prop('selected', true)
-    }
-} */
 
 function showAddNewAPIDiv() {
     //console.debug('showing div for adding new API')
@@ -257,27 +109,18 @@ function disableAPIEdit() {
     $("#apiTitle").text('')
 }
 
-async function populateAPIValues(api) {
-    console.debug(api)
-    $("#selectedAPI").val(api.name)
-    $("#endpoint").val(api.key)
-    $("#key").val(api.endpoint)
-    $("#type").find(`option[value="${api.endpointType}"]`).prop('selected', true)
-    $("#claude").prop('checked', api.claude)
-    // hide the add button, only do it through the selector
-    // can change this later if we need to, if a button is more intuitive.
-    $("#addNewAPIButton").hide()
-    $("#editAPIButton").show()
-    $("#apiTitle").text('API Info')
-    $("#modelLoadButton").trigger('click')
-}
+async function testNewAPI() {
+    let name = $("#selectedAPI").val()
+    let endpoint = $("#endpoint").val()
+    let key = $("#key").val()
+    let type = $("#type").val()
+    let claude = $("#claude").prop('checked')
 
-function testNewAPI() {
-    let name = $("#newAPIName").val()
-    let endpoint = $("#newAPIEndpoint").val()
-    let key = $("#newAPIKey").val()
-    let type = $("#newAPIEndpointType").val()
-    let claude = $("#isClaudeCheckbox").prop('checked')
+    if (endpoint.includes('localhost:')) {
+        await util.flashElement('endpoint', 'bad')
+        alert('For local connections use 127.0.0.1, not localhost')
+        return
+    }
 
     util.messageServer({
         type: 'testNewAPI',
@@ -374,28 +217,16 @@ function showPastChats(chatList) {
 }
 
 export default {
-    //populateAPISelector,
-    //populateSelector,
     submitKey,
     updateUserName,
-    updateD1JBInput,
-    updateInstructFormat,
-    updateSelectedSamplerPreset,
-    updateSelectedChar,
     updateAIChatUserName,
-    updateAPI,
-    //populateAPIValues,
     showAddNewAPIDiv,
     hideAddNewAPIDiv,
-    //addNewAPI,
     testNewAPI,
     getModelList,
     enableAPIEdit,
     disableAPIEdit,
     populateModelsList,
     updateSelectedModel,
-    updateD4ANInput,
-    updateSystemPromptInput,
     showPastChats,
-
 }

--- a/public/src/handleconfig.js
+++ b/public/src/handleconfig.js
@@ -28,9 +28,10 @@ Based on the following array sent from server:
               key,
               type,
               claude,
-              value
+              value              //this is a copy of 'name' for selector population purposes
             },
           selectedAPI,          //just the name
+          isAutoResponse,     //boolean for checkbox
       },
       APIConfig: {
               selectedAPI,        //selector value, matches the value of one of the 'name' props in above APIList
@@ -39,13 +40,12 @@ Based on the following array sent from server:
               endpointType,       //selector value
               claude,             //checkbox
               selectedModel,      //selector value, matches an item from the modelList below
-              modelList: {}        //list for a selector
+              modelList: {}       //list for a selector
           },
       },
       crowdControl: {
           userChatDelay,      //number input value
           AIChatDelay,           //number input value
-          isAutoResponse,     //boolean for checkbox
       },
   ]
 */
@@ -218,7 +218,7 @@ async function toggleCheckbox(value, elementID) {
 }
 
 async function checkArguments(functionName, args, isSelectorCheck = false) {
-  return true //comment this line if we need to lint the DOM or args being passed
+  //return true //comment this line if we need to lint the DOM or args being passed
 
 
   const [value, elementID, selectedValue] = args;
@@ -253,7 +253,6 @@ async function checkArguments(functionName, args, isSelectorCheck = false) {
   if (areValuesTheSame) {
     return false
   }
-
 
   return true;
 }
@@ -291,11 +290,15 @@ async function verifyValuesAreTheSame(value, elementID) {
   } else {
     elementValue = $element.val();
   }
-  let result = elementValue === value ? true : false
-  if (!result) {
-    console.log(`Compared values for ${elementID}:
-    New "${value}"
-    Old "${elementValue}"
+
+  //console.log('elementValue:', elementValue);
+  //console.log('value:', value);
+  let result = elementValue === value
+  //console.log('result:', result);
+  if (result === false) {
+    console.debug(`Compared values for ${elementID}:
+    New ${value}
+    Old ${elementValue}
     Needs update!`);
   }
   return result;
@@ -361,8 +364,8 @@ async function updateConfigState(element) {
 
   if ($element.is('input[type=checkbox]')) {
     value = $element.prop('checked')
-    if (value = 0) { value = false }
-    if (value = 1) { value = true }
+    if (value === 0) { value = false }
+    if (value === 1) { value = true }
   }
   else { // selectors and text inputs
     value = $element.val()
@@ -458,6 +461,13 @@ async function addNewAPI() {
     alert(`This name is reserved by system.`)
     return
   }
+
+  if (endpoint.includes('localhost:')) {
+    await util.flashElement('endpoint', 'bad')
+    alert('For local connections use 127.0.0.1, not localhost')
+    return
+  }
+
   if (endpoint === '' || !util.isValidURL(endpoint)) {
     await util.flashElement('endpoint', 'bad')
     alert(`Invalid URL structure.`)
@@ -472,12 +482,20 @@ async function addNewAPI() {
     claude: claude,
   }
 
-  liveConfig.promptConfig.APIList.push(newAPI)
+  let matchingAPI = liveConfig.promptConfig.APIList.findIndex(obj => obj.name === newAPI.name);
+
+  if (matchingAPI !== -1) {
+    // Replace the object at the found index with newAPI
+    liveConfig.promptConfig.APIList[matchingAPI] = newAPI;
+  } else {
+    // Add newAPI to the array
+    liveConfig.promptConfig.APIList.push(newAPI);
+  }
+
   liveConfig.promptConfig.selectedAPI = name
-  liveConfig.promptConfig.APIConfig = newAPI
+  liveConfig.APIConfig = newAPI
   liveAPI = newAPI
   APIConfig = newAPI
-
 
   console.log(APIConfig)
   console.log(liveAPI)

--- a/public/src/handleconfig.js
+++ b/public/src/handleconfig.js
@@ -96,10 +96,7 @@ async function processLiveConfig(configArray) {
   await populateInput(selectedAPI, "selectedAPI");
 
   await populateSelector(samplerPresetList, "samplerPresetList", selectedSamplerPreset);
-  console.log('SETTING INSTRUCT NOW')
-  console.log(selectedInstruct)
   await populateSelector(instructList, "instructList", selectedInstruct);
-  console.log(liveConfig.promptConfig.selectedInstruct)
 
   await selectFromPopulatedSelector(responseLength, "responseLength");
   await selectFromPopulatedSelector(contextSize, "contextSize");
@@ -306,7 +303,7 @@ async function verifyValuesAreTheSame(value, elementID) {
 
 // set the engine mode to either horde or Text Completions based on a value from the websocket
 async function setEngineMode(mode) {
-  console.log("API MODE:", mode);
+  console.debug("API MODE:", mode);
   const toggleModeElement = $("#toggleMode");
   const isHordeMode = mode === "horde";
   toggleModeElement

--- a/public/src/utils.js
+++ b/public/src/utils.js
@@ -12,6 +12,11 @@ function debounce(func, delay) {
     };
 }
 
+function isValidURL(url) {
+    const urlRegex = /^(http(s)?:\/\/)?[\w.-]+\.[a-zA-Z]{2,3}(\.[a-zA-Z]{2,3})?\/?$/;
+    return urlRegex.test(url);
+}
+
 //target and reference are both JQuery DOM objects ala $("#myDiv")
 function setHeightToDivHeight(target, reference) {
     if (target.hasClass('isAnimating') || reference.hasClass('isAnimating')) {
@@ -305,4 +310,5 @@ export default {
     convertNonsenseTokensToUTF,
     messageServer,
     kindlyScrollDivToBottom,
+    isValidURL,
 }    

--- a/public/src/utils.js
+++ b/public/src/utils.js
@@ -91,8 +91,8 @@ function heartbeat() {
 }
 
 function checkIsLandscape() {
-    console.log('checking landscape or not..')
-    console.log($(window).height(), $(window).width())
+    console.debug('checking landscape or not..')
+    console.debug($(window).height(), $(window).width())
     if ($(window).height() > $(window).width()) { return false }
     else { return true }
 }
@@ -220,7 +220,8 @@ function heightMinusDivHeight(container, childToSubtract = null) {
         let gapCope = (containerGapSize * numberOfContainerGaps) + (numChildGaps * childGapSize)
 
         let remainingHeight = containerHeight - childHeight - gapCope - containerPaddingTop - containerPaddingBottom + "px"
-        console.log(`${containerHeight} - ${childHeight} - ((${numberOfContainerGaps}*${containerGapSize}) + (${numChildGaps}*${childGapSize})) - ${containerPaddingTop} - ${containerPaddingBottom} = ${remainingHeight}px`)
+
+        console.debug(`Returning height for ${container} as: ${containerHeight} - ${childHeight} - ((${numberOfContainerGaps}*${containerGapSize}) + (${numChildGaps}*${childGapSize})) - ${containerPaddingTop} - ${containerPaddingBottom} = ${remainingHeight}px`)
         return remainingHeight
     } else {
         return container.outerHeight()

--- a/public/src/utils.js
+++ b/public/src/utils.js
@@ -13,7 +13,7 @@ function debounce(func, delay) {
 }
 
 function isValidURL(url) {
-    const urlRegex = /^(http(s)?:\/\/)?[\w.-]+\.[a-zA-Z]{2,3}(\.[a-zA-Z]{2,3})?\/?$/;
+    const urlRegex = /^((?:[\w-]+:\/\/|)(?:[\d.]+|localhost)(?::\d+)?(?:\/[\w.-]*)*\/?)$/;
     return urlRegex.test(url);
 }
 

--- a/src/character-card-parser.js
+++ b/src/character-card-parser.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 
 const extract = require('png-chunks-extract');
 const PNGtext = require('png-chunk-text');
-const { charLogger : logger } = require('./log.js');
+const { charLogger: logger } = require('./log.js');
 
 const parse = async (cardUrl, format) => {
     let fileFormat = format === undefined ? 'png' : format;
@@ -17,8 +17,8 @@ const parse = async (cardUrl, format) => {
             }).map(function (chunk) {
                 return PNGtext.decode(chunk.data);
             });
-            logger.trace('textChunks in CCP.js')
-            logger.trace(textChunks)
+            //logger.trace('textChunks in CCP.js')
+            //logger.trace(textChunks)
 
             if (textChunks.length === 0) {
                 logger.error('PNG metadata does not contain any character data.');

--- a/src/db.js
+++ b/src/db.js
@@ -346,23 +346,23 @@ async function upsertUserRole(uuid, role) {
 }
 
 // Create or update the character in the database
-async function upsertChar(uuid, displayname, color) {
-    //logger.debug('Adding/updating character...' + uuid);
+async function upsertChar(char_id, displayname, color) {
+    logger.debug(`Adding/updating ${displayname} (${char_id})`);
     const db = await dbPromise;
     try {
-        const existingRow = await db.get('SELECT displayname FROM characters WHERE char_id = ?', [uuid]);
+        const existingRow = await db.get('SELECT displayname FROM characters WHERE char_id = ?', [char_id]);
 
         if (!existingRow) {
             // Case 1: Row with matching uuid doesn't exist, create a new row
-            await db.run('INSERT INTO characters (char_id, displayname, display_color, last_seen_at) VALUES (?, ?, ?, CURRENT_TIMESTAMP)', [uuid, displayname, color]);
-            logger.debug(`A new character was inserted, ${uuid}, ${displayname}`);
+            await db.run('INSERT INTO characters (char_id, displayname, display_color, last_seen_at) VALUES (?, ?, ?, CURRENT_TIMESTAMP)', [char_id, displayname, color]);
+            logger.debug(`A new character was inserted, ${char_id}, ${displayname}`);
         } else if (existingRow.displayname !== displayname) {
             // Case 2: Row with matching uuid exists, but displayname is different, update displayname and last_seen_at
-            await db.run('UPDATE characters SET displayname = ?, last_seen_at = CURRENT_TIMESTAMP WHERE char_id = ?', [displayname, uuid]);
+            await db.run('UPDATE characters SET displayname = ?, last_seen_at = CURRENT_TIMESTAMP WHERE char_id = ?', [displayname, char_id]);
             logger.debug(`Updated displayname for character from ${existingRow.displayname} to ${displayname}`);
         } else {
             // Case 3: Row with matching uuid AND displayname exists, only update last_seen_at
-            await db.run('UPDATE characters SET last_seen_at = CURRENT_TIMESTAMP WHERE char_id = ?', [uuid]);
+            await db.run('UPDATE characters SET last_seen_at = CURRENT_TIMESTAMP WHERE char_id = ?', [char_id]);
             //logger.debug('Last seen timestamp was updated');
         }
     } catch (err) {

--- a/src/file-io.js
+++ b/src/file-io.js
@@ -199,13 +199,13 @@ async function getCardList() {
             let fullPath = `${path}/${file}`
             const cardData = await charaRead(fullPath);
             var jsonData = JSON.parse(cardData);
-            jsonData.filename = `${path}/${file}`
+            jsonData.filename = fullPath
             cards[i] = {
                 name: jsonData.name,
                 value: jsonData.filename
             }
             thisCharColor = charnameColors[Math.floor(Math.random() * charnameColors.length)];
-            db.upsertChar(jsonData.value, jsonData.name, thisCharColor)
+            db.upsertChar(jsonData.filename, jsonData.name, thisCharColor)
         } catch (error) {
             logger.error(`Error reading file ${file}:`, error);
         }

--- a/src/file-io.js
+++ b/src/file-io.js
@@ -87,23 +87,39 @@ async function readConfig() {
     });
 }
 
-async function writeConfig(configObj, key, value) {
-    await acquireLock()
-    await delay(100)
-    //let newObject = await readConfig()
+async function writeConfig(configObj, key = null, value = null) {
+    await acquireLock();
+    await delay(100);
+
     if (key) {
-        configObj[key] = value;
-        logger.debug(`Config updated: ${key}`); // = ${value}`);
+        const parts = key.split(".");
+        let currentObj = configObj;
+
+        for (let i = 0; i < parts.length - 1; i++) {
+            const part = parts[i];
+
+            if (!(part in currentObj)) {
+                currentObj[part] = {};
+            }
+
+            currentObj = currentObj[part];
+        }
+
+        currentObj[parts[parts.length - 1]] = value;
+
+        logger.debug(`Config updated: ${key}`);
     }
-    const writableConfig = JSON.stringify(configObj, null, 2); // Serialize the object with indentation
-    fs.writeFile('./config.json', writableConfig, 'utf8', writeErr => {
+
+    const writableConfig = JSON.stringify(configObj, null, 2);
+    fs.writeFile("./config.json", writableConfig, "utf8", writeErr => {
         if (writeErr) {
-            logger.error('An error occurred while writing to the file:', writeErr);
-            releaseLock()
+            logger.error("An error occurred while writing to the file:", writeErr);
+            releaseLock();
             return;
         }
-        logger.debug('config.json updated.');
-        releaseLock()
+
+        logger.debug("config.json updated.");
+        releaseLock();
     });
 }
 

--- a/src/file-io.js
+++ b/src/file-io.js
@@ -188,7 +188,7 @@ async function charaRead(img_url, input_format) {
 }
 
 async function getCardList() {
-    console.debug('Gathering character card list..')
+    logger.info('Gathering character card list..')
     const path = 'public/characters'
     const files = await fs.promises.readdir(path);
     var cards = []


### PR DESCRIPTION
This update refactors how server/client configurations are updated. Users may need to delete their config.json and let the server make a new one.

This was done to reduce the ever-growing logic for handling WebSocket messages. script.js went from 45 cases to 26, and server.js only has 16 if/thens for messages. There is still room for further optimization.

Instead of individual message types for each setting update, all settings are combined into a single message type that contains a common array known as `liveConfig`.

liveConfig contains information for every control panel input, and the full details of every registered API.

_(Note that while liveConfig is only sent to users who have the Host role, I can see this as a potential security issue, and will probably change this to only send the names of every API for selector population purposes, and only send the currently active API's full details)._

Each time any setting is changed by a Host, the server is updated with the entire setting state of that user. The server saves those settings to config.json, and then broadcasts them to all other Hosts (and Guests where applicable). 

Of course, forcing change for every setting each time one of them is updated would be costly, so logic is in place on the client end to only change settings that have been given different values.

Additionally, sampler settings and instruct formats are no longer saved in config.json, and are not sent to the client. Instead they handled entirely in the server, using the selected preset/format option's value (its file path) as a reference for the server to pull from when needed. 

New features: 
- delete APIs from db via the UI
- auto validation of API urls during test and saving
- better error reporting during API interactions
- more relaxed requirements for API urls (ex: the string `127.0.0.1:5000` is acceptable; no need for http:// prefix or an ending forward slash)

Currently Broken: 
- model list does not work at all
- on first load there is no greeting message shown in the chat (but chatting will work, and a first message will be shown normally if you clear AI chat once)

Currently acting weird:
- when a Host updates a setting, the server pings them back with the full setting array. This results in 'double flashing' of the changed inputs, but otherwise has no real harmful effects. I'll fix this so that the client initiating a settings change is exempt from the broadcast.
