### PR TITLE
Remove trailing slash from the model endpoint URL

### DIFF
--- a/src/api-calls.js
+++ b/src/api-calls.js
@@ -594,7 +594,7 @@ async function getModelList(api) {
 
 
 
-    modelsEndpoint = modelsEndpoint + 'models/'
+    modelsEndpoint = modelsEndpoint + 'models'
     let key = 'Bearer ' + api.key
 
     let headers = {


### PR DESCRIPTION
Fetching model list from `https://api.openai.com/v1/models` with trailing slash causes an error on OpenAI's side. After removing the slash, the model list is being fetched as it should.

**Error:** ![Screenshot 2024-01-15 040834](https://github.com/RossAscends/STMP/assets/156625788/0dc2a666-7ee1-4b02-bb9e-3adc87457f09)

**Model list at**  `https://api.openai.com/v1/models`**:** 
![model_list](https://github.com/RossAscends/STMP/assets/156625788/8369e224-a762-4680-82aa-e8dc7cc626d2)
